### PR TITLE
NIC starting up with configured IP rather than an automatic 169.x.x.x

### DIFF
--- a/WgAPI/Commands/WireGuardCommand.cs
+++ b/WgAPI/Commands/WireGuardCommand.cs
@@ -1,4 +1,7 @@
-﻿namespace WgAPI
+﻿using System.IO;
+using System.Text;
+
+namespace WgAPI
 {
     public class WireGuardCommand
     {
@@ -16,6 +19,34 @@
         public WhichExe WhichExe { get; protected set; }
 
         public string StandardInput { get; protected set; } = string.Empty;
+
+
+        /// <summary>
+        /// Remove "WireGuard.exe" / "wg-quick" specific settings which aren't supported by "wg.exe" / "wg".
+        /// This is similar to the "wg-quick strip" command under Linux, used for example in: wg syncconf wg0 &lt;(wg-quick strip wg0)
+        /// Make sure to pass a temporary file path to avoid overwriting the original configuration.
+        /// </summary>
+        /// <param name="temporaryFilePath"></param>
+        public static void StripConfigFile(string temporaryFilePath)
+        {
+            var lines = File.ReadAllLines(temporaryFilePath);
+            var section = "";
+            var sb = new StringBuilder((int)new FileInfo(temporaryFilePath).Length);
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine.Trim();
+                if (line.StartsWith('[') && line.EndsWith(']'))
+                    section = line.Substring(1, line.Length - 2);
+
+                // "[Interface] Address=..." isn't supported by wg (i.e.: wg syncconf)
+                if (section == "Interface" && line.Replace(" ", "").StartsWith("Address="))
+                    continue;
+
+                sb.AppendLine(rawLine);
+            }
+
+            File.WriteAllText(temporaryFilePath, sb.ToString());
+        }
     }
 
     public enum WhichExe

--- a/WgServerforWindows/Models/ClientConfigurationsPrerequisite.cs
+++ b/WgServerforWindows/Models/ClientConfigurationsPrerequisite.cs
@@ -170,8 +170,11 @@ namespace WgServerforWindows.Models
                 // Update the tunnel service, if everyone is happy
                 if ((Fulfilled || !AnyClients) && serverConfigurationPrerequisite.Fulfilled && new TunnelServicePrerequisite().Fulfilled)
                 {
-                    using (TemporaryFile temporaryFile = new(originalFilePath: ServerConfigurationPrerequisite.ServerWGPath, newFilePath: ServerConfigurationPrerequisite.ServerWGPathWithCustomTunnelName))
+                    using (TemporaryFile temporaryFile = new(originalFilePath: ServerConfigurationPrerequisite.ServerWGPath, newFilePath: ServerConfigurationPrerequisite.ServerWGPathWithCustomTunnelName + ".tmp"))
                     {
+                        // remove config settings that arent's supported by wg
+                        WireGuardCommand.StripConfigFile(temporaryFile.NewFilePath);
+
                         string output = new WireGuardExe().ExecuteCommand(new SyncConfigurationCommand(GlobalAppSettings.Instance.TunnelServiceName, temporaryFile.NewFilePath), out int exitCode);
 
                         if (exitCode != 0)

--- a/WgServerforWindows/Models/ServerConfiguration.cs
+++ b/WgServerforWindows/Models/ServerConfiguration.cs
@@ -16,7 +16,7 @@ namespace WgServerforWindows.Models
         {
             // Server properties
             PrivateKeyProperty.TargetTypes.Add(GetType());
-            //AddressProperty.TargetTypes.Add(GetType());
+            AddressProperty.TargetTypes.Add(GetType());
             ListenPortProperty.TargetTypes.Add(GetType());
 
             // Client properties

--- a/WgServerforWindows/Models/ServerConfigurationPrerequisite.cs
+++ b/WgServerforWindows/Models/ServerConfigurationPrerequisite.cs
@@ -124,8 +124,11 @@ namespace WgServerforWindows.Models
                 // Update the tunnel service, if everyone is happy
                 if (Fulfilled && (clientConfigurationsPrerequisite.Fulfilled || !ClientConfigurationsPrerequisite.AnyClients) && new TunnelServicePrerequisite().Fulfilled)
                 {
-                    using (TemporaryFile temporaryFile = new(ServerWGPath, ServerWGPathWithCustomTunnelName))
+                    using (TemporaryFile temporaryFile = new(ServerWGPath, ServerWGPathWithCustomTunnelName + ".tmp"))
                     {
+                        // remove config settings that arent's supported by wg
+                        WireGuardCommand.StripConfigFile(temporaryFile.NewFilePath);
+
                         // Sync conf to tunnel
                         string output = new WireGuardExe().ExecuteCommand(new SyncConfigurationCommand(GlobalAppSettings.Instance.TunnelServiceName, temporaryFile.NewFilePath), out int exitCode);
 


### PR DESCRIPTION
- bring up the network interface with the configured IP (by adding the [Interface] Address=... line to wg_server.config)

- added WireGuardCommand.StripConfigFile() to remove WireGuard.exe specific settings from a config file which aren't supported by the wg.exe command (e.g. with "wg syncconf")